### PR TITLE
READ処理に対するServiceテストの実装、DBテーブルのTimeStamp型をDateTime型に変更

### DIFF
--- a/sql/orders.sql
+++ b/sql/orders.sql
@@ -5,6 +5,6 @@ CREATE TABLE orders (
   car_type_id int unsigned NOT NULL,
   order_status_id int unsigned NOT NULL,
   created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  updated_at datetime NOT NULL DEFAULT 0000-00-00 00:00:00 ON UPDATE CURRENT_TIMESTAMP,
+  updated_at datetime ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY(id)
 );

--- a/sql/orders.sql
+++ b/sql/orders.sql
@@ -4,6 +4,7 @@ CREATE TABLE orders (
   id int unsigned AUTO_INCREMENT,
   car_type_id int unsigned NOT NULL,
   order_status_id int unsigned NOT NULL,
-  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at datetime NOT NULL DEFAULT 0000-00-00 00:00:00 ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY(id)
 );

--- a/sql/staffs.sql
+++ b/sql/staffs.sql
@@ -4,6 +4,7 @@ CREATE TABLE staffs (
   id int unsigned AUTO_INCREMENT,
   section_id int unsigned NOT NULL,
   staff_status_id int unsigned NOT NULL,
-    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at datetime NOT NULL DEFAULT 0000-00-00 00:00:00 ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY(id)
 );

--- a/sql/staffs.sql
+++ b/sql/staffs.sql
@@ -5,6 +5,6 @@ CREATE TABLE staffs (
   section_id int unsigned NOT NULL,
   staff_status_id int unsigned NOT NULL,
   created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  updated_at datetime NOT NULL DEFAULT 0000-00-00 00:00:00 ON UPDATE CURRENT_TIMESTAMP,
+  updated_at datetime ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY(id)
 );

--- a/src/main/java/com/pon02/Assignment10/controller/CarTypeController.java
+++ b/src/main/java/com/pon02/Assignment10/controller/CarTypeController.java
@@ -23,6 +23,6 @@ public class CarTypeController {
 
     @GetMapping("/car-types/{id}")
     public CarType getCarTypeById(@PathVariable int id) {
-        return carTypeService.findCarTypeById(id);
+        return carTypeService.CarTypeFindById(id);
     }
 }

--- a/src/main/java/com/pon02/Assignment10/controller/CarTypeController.java
+++ b/src/main/java/com/pon02/Assignment10/controller/CarTypeController.java
@@ -23,6 +23,6 @@ public class CarTypeController {
 
     @GetMapping("/car-types/{id}")
     public CarType getCarTypeById(@PathVariable int id) {
-        return carTypeService.carTypeFindById(id);
+        return carTypeService.findCarTypeById(id);
     }
 }

--- a/src/main/java/com/pon02/Assignment10/controller/CarTypeController.java
+++ b/src/main/java/com/pon02/Assignment10/controller/CarTypeController.java
@@ -23,6 +23,6 @@ public class CarTypeController {
 
     @GetMapping("/car-types/{id}")
     public CarType getCarTypeById(@PathVariable int id) {
-        return carTypeService.CarTypeFindById(id);
+        return carTypeService.carTypeFindById(id);
     }
 }

--- a/src/main/java/com/pon02/Assignment10/entity/CarType.java
+++ b/src/main/java/com/pon02/Assignment10/entity/CarType.java
@@ -30,9 +30,7 @@ public class CarType {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         CarType carType = (CarType) o;
-        return id == carType.id &&
-                capacity == carType.capacity &&
-                Objects.equals(carType, carType.carType);
+        return id == carType.id && capacity == carType.capacity && Objects.equals(this.carType, carType.carType);
     }
 
     @Override

--- a/src/main/java/com/pon02/Assignment10/entity/Order.java
+++ b/src/main/java/com/pon02/Assignment10/entity/Order.java
@@ -1,16 +1,21 @@
 package com.pon02.Assignment10.entity;
 
+import org.springframework.cglib.core.Local;
+
 import java.sql.Timestamp;
+
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.Objects;
 
 public class Order {
     private int id;
     private int carTypeId;
     private int orderStatusId;
-    private Timestamp createdAt;
-    private Timestamp updatedAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 
-    public Order(int id, int carTypeId, int carStatusId, Timestamp createdAt, Timestamp updatedAt) {
+    public Order(int id, int carTypeId, int carStatusId, LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
         this.carTypeId = carTypeId;
         this.orderStatusId = carStatusId;
@@ -30,11 +35,11 @@ public class Order {
         return orderStatusId;
     }
 
-    public Timestamp getCreatedAt() {
+    public LocalDateTime getCreatedAt() {
         return createdAt;
     }
 
-    public Timestamp getUpdatedAt() {
+    public LocalDateTime getUpdatedAt() {
         return updatedAt;
     }
 

--- a/src/main/java/com/pon02/Assignment10/mapper/CarTypeMapper.java
+++ b/src/main/java/com/pon02/Assignment10/mapper/CarTypeMapper.java
@@ -13,5 +13,5 @@ public interface CarTypeMapper {
     List<CarType> findAllCarTypes();
 
     @Select("SELECT * FROM car_types WHERE id = #{id}")
-    Optional<CarType> CarTypeFindById(int id);
+    Optional<CarType> carTypeFindById(int id);
 }

--- a/src/main/java/com/pon02/Assignment10/mapper/CarTypeMapper.java
+++ b/src/main/java/com/pon02/Assignment10/mapper/CarTypeMapper.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 @Mapper
 public interface CarTypeMapper {
     @Select("SELECT * FROM car_types")
-    List<CarType> CarTypeFindAll();
+    List<CarType> findAllCarTypes();
 
     @Select("SELECT * FROM car_types WHERE id = #{id}")
     Optional<CarType> CarTypeFindById(int id);

--- a/src/main/java/com/pon02/Assignment10/mapper/CarTypeMapper.java
+++ b/src/main/java/com/pon02/Assignment10/mapper/CarTypeMapper.java
@@ -13,5 +13,5 @@ public interface CarTypeMapper {
     List<CarType> findAllCarTypes();
 
     @Select("SELECT * FROM car_types WHERE id = #{id}")
-    Optional<CarType> carTypeFindById(int id);
+    Optional<CarType> findCarTypeById(int id);
 }

--- a/src/main/java/com/pon02/Assignment10/mapper/OrderMapper.java
+++ b/src/main/java/com/pon02/Assignment10/mapper/OrderMapper.java
@@ -8,5 +8,5 @@ import java.util.List;
 @Mapper
 public interface OrderMapper {
     @Select("SELECT * FROM orders")
-    List<Order> OrdersFindAll();
+    List<Order> findAllOrders();
 }

--- a/src/main/java/com/pon02/Assignment10/service/CarTypeService.java
+++ b/src/main/java/com/pon02/Assignment10/service/CarTypeService.java
@@ -19,8 +19,8 @@ public class CarTypeService {
         return this.carTypeMapper.findAllCarTypes();
     }
 
-    public CarType CarTypeFindById(int id) {
-        return this.carTypeMapper.CarTypeFindById(id)
+    public CarType carTypeFindById(int id) {
+        return this.carTypeMapper.carTypeFindById(id)
                .orElseThrow(() -> new CarTypeNotFoundException("Car type not found for id: " + id));
     }
 }

--- a/src/main/java/com/pon02/Assignment10/service/CarTypeService.java
+++ b/src/main/java/com/pon02/Assignment10/service/CarTypeService.java
@@ -16,10 +16,10 @@ public class CarTypeService {
     }
 
     public List<CarType> findAllCarTypes() {
-        return this.carTypeMapper.CarTypeFindAll();
+        return this.carTypeMapper.findAllCarTypes();
     }
 
-    public CarType findCarTypeById(int id) {
+    public CarType CarTypeFindById(int id) {
         return this.carTypeMapper.CarTypeFindById(id)
                .orElseThrow(() -> new CarTypeNotFoundException("Car type not found for id: " + id));
     }

--- a/src/main/java/com/pon02/Assignment10/service/CarTypeService.java
+++ b/src/main/java/com/pon02/Assignment10/service/CarTypeService.java
@@ -19,8 +19,8 @@ public class CarTypeService {
         return this.carTypeMapper.findAllCarTypes();
     }
 
-    public CarType carTypeFindById(int id) {
-        return this.carTypeMapper.carTypeFindById(id)
+    public CarType findCarTypeById(int id) {
+        return this.carTypeMapper.findCarTypeById(id)
                .orElseThrow(() -> new CarTypeNotFoundException("Car type not found for id: " + id));
     }
 }

--- a/src/main/java/com/pon02/Assignment10/service/OrderService.java
+++ b/src/main/java/com/pon02/Assignment10/service/OrderService.java
@@ -14,6 +14,6 @@ public class OrderService {
     }
 
     public List<Order> findAllOrders()  {
-        return this.orderMapper.OrdersFindAll();
+        return this.orderMapper.findAllOrders();
     }
 }

--- a/src/test/java/com/pon02/Assignment10/service/CarTypeServiceTest.java
+++ b/src/test/java/com/pon02/Assignment10/service/CarTypeServiceTest.java
@@ -41,20 +41,20 @@ class CarTypeServiceTest {
     @Test
     public void カータイプIDでカータイプを取得できる() {
         doReturn(Optional.of(new CarType(1, "セダン4人", 4)))
-                .when(carTypeMapper).carTypeFindById(1);
-        CarType actual = carTypeService.carTypeFindById(1);
+                .when(carTypeMapper).findCarTypeById(1);
+        CarType actual = carTypeService.findCarTypeById(1);
         assertThat(actual).isEqualTo(new CarType(1, "セダン4人", 4));
-        verify(carTypeMapper, times(1)).carTypeFindById(1);
+        verify(carTypeMapper, times(1)).findCarTypeById(1);
     }
 
     @Test
     public void カータイプIDが存在しない場合例外がスローされること() {
         doReturn(Optional.empty())
-                .when(carTypeMapper).carTypeFindById(100);
-        assertThatThrownBy(() -> carTypeService.carTypeFindById(100))
+                .when(carTypeMapper).findCarTypeById(100);
+        assertThatThrownBy(() -> carTypeService.findCarTypeById(100))
                 .isInstanceOfSatisfying(CarTypeNotFoundException.class, e -> {
                     assertThat(e.getMessage()).isEqualTo("Car type not found for id: 100");
                 });
-        verify(carTypeMapper, times(1)).carTypeFindById(100);
+        verify(carTypeMapper, times(1)).findCarTypeById(100);
     }
 }

--- a/src/test/java/com/pon02/Assignment10/service/CarTypeServiceTest.java
+++ b/src/test/java/com/pon02/Assignment10/service/CarTypeServiceTest.java
@@ -41,20 +41,20 @@ class CarTypeServiceTest {
     @Test
     public void カータイプIDでカータイプを取得できる() {
         doReturn(Optional.of(new CarType(1, "セダン4人", 4)))
-                .when(carTypeMapper).CarTypeFindById(1);
-        CarType actual = carTypeService.CarTypeFindById(1);
+                .when(carTypeMapper).carTypeFindById(1);
+        CarType actual = carTypeService.carTypeFindById(1);
         assertThat(actual).isEqualTo(new CarType(1, "セダン4人", 4));
-        verify(carTypeMapper, times(1)).CarTypeFindById(1);
+        verify(carTypeMapper, times(1)).carTypeFindById(1);
     }
 
     @Test
     public void カータイプIDが存在しない場合例外がスローされること() {
         doReturn(Optional.empty())
-                .when(carTypeMapper).CarTypeFindById(100);
-        assertThatThrownBy(() -> carTypeService.CarTypeFindById(100))
+                .when(carTypeMapper).carTypeFindById(100);
+        assertThatThrownBy(() -> carTypeService.carTypeFindById(100))
                 .isInstanceOfSatisfying(CarTypeNotFoundException.class, e -> {
                     assertThat(e.getMessage()).isEqualTo("Car type not found for id: 100");
                 });
-        verify(carTypeMapper, times(1)).CarTypeFindById(100);
+        verify(carTypeMapper, times(1)).carTypeFindById(100);
     }
 }

--- a/src/test/java/com/pon02/Assignment10/service/CarTypeServiceTest.java
+++ b/src/test/java/com/pon02/Assignment10/service/CarTypeServiceTest.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class CarTypeServiceTest {
@@ -35,7 +35,7 @@ class CarTypeServiceTest {
         assertThat(actual).isEqualTo(List.of(
                 new CarType(1, "セダン4人", 4),
                 new CarType(2, "ハコバン7人", 7)));
-
+        verify(carTypeMapper, times(1)).findAllCarTypes();
     }
 
     @Test
@@ -44,6 +44,7 @@ class CarTypeServiceTest {
                 .when(carTypeMapper).CarTypeFindById(1);
         CarType actual = carTypeService.CarTypeFindById(1);
         assertThat(actual).isEqualTo(new CarType(1, "セダン4人", 4));
+        verify(carTypeMapper, times(1)).CarTypeFindById(1);
     }
 
     @Test
@@ -54,5 +55,6 @@ class CarTypeServiceTest {
                 .isInstanceOfSatisfying(CarTypeNotFoundException.class, e -> {
                     assertThat(e.getMessage()).isEqualTo("Car type not found for id: 100");
                 });
+        verify(carTypeMapper, times(1)).CarTypeFindById(100);
     }
 }

--- a/src/test/java/com/pon02/Assignment10/service/CarTypeServiceTest.java
+++ b/src/test/java/com/pon02/Assignment10/service/CarTypeServiceTest.java
@@ -1,0 +1,58 @@
+package com.pon02.Assignment10.service;
+
+import com.pon02.Assignment10.entity.CarType;
+import com.pon02.Assignment10.exception.CarTypeNotFoundException;
+import com.pon02.Assignment10.mapper.CarTypeMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doReturn;
+
+@ExtendWith(MockitoExtension.class)
+class CarTypeServiceTest {
+
+    @InjectMocks
+    private CarTypeService carTypeService;
+
+    @Mock
+    private CarTypeMapper carTypeMapper;
+
+    @Test
+    public void 全てのカータイプを取得できる() {
+        doReturn(List.of(
+                new CarType(1, "セダン4人", 4),
+                new CarType(2, "ハコバン7人", 7)))
+                .when(carTypeMapper).findAllCarTypes();
+        List<CarType> actual = carTypeService.findAllCarTypes();
+        assertThat(actual).isEqualTo(List.of(
+                new CarType(1, "セダン4人", 4),
+                new CarType(2, "ハコバン7人", 7)));
+
+    }
+
+    @Test
+    public void カータイプIDでカータイプを取得できる() {
+        doReturn(Optional.of(new CarType(1, "セダン4人", 4)))
+                .when(carTypeMapper).CarTypeFindById(1);
+        CarType actual = carTypeService.CarTypeFindById(1);
+        assertThat(actual).isEqualTo(new CarType(1, "セダン4人", 4));
+    }
+
+    @Test
+    public void カータイプIDが存在しない場合例外がスローされること() {
+        doReturn(Optional.empty())
+                .when(carTypeMapper).CarTypeFindById(100);
+        assertThatThrownBy(() -> carTypeService.CarTypeFindById(100))
+                .isInstanceOfSatisfying(CarTypeNotFoundException.class, e -> {
+                    assertThat(e.getMessage()).isEqualTo("Car type not found for id: 100");
+                });
+    }
+}

--- a/src/test/java/com/pon02/Assignment10/service/OrderServiceTest.java
+++ b/src/test/java/com/pon02/Assignment10/service/OrderServiceTest.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.*;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -34,5 +34,6 @@ class OrderServiceTest {
         assertThat(actual).isEqualTo(List.of(
                 new Order(1, 1, 2, LocalDateTime.of(2024,5,2,9,0,0), LocalDateTime.of(2024,5,2,9,5,0)),
                 new Order(2, 2, 1, LocalDateTime.of(2024,5,2,9,2,0), null)));
+        verify(orderMapper,times(1)).findAllOrders();
     }
 }

--- a/src/test/java/com/pon02/Assignment10/service/OrderServiceTest.java
+++ b/src/test/java/com/pon02/Assignment10/service/OrderServiceTest.java
@@ -1,0 +1,38 @@
+package com.pon02.Assignment10.service;
+
+import com.pon02.Assignment10.entity.Order;
+import com.pon02.Assignment10.mapper.OrderMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+
+    @InjectMocks
+    private OrderService orderService;
+
+    @Mock
+    private OrderMapper orderMapper;
+
+    @Test
+    public void 全てのオーダーを取得できる() {
+        doReturn(List.of(
+                new Order(1, 1, 2, LocalDateTime.of(2024,5,2,9,0,0), LocalDateTime.of(2024,5,2,9,5,0)),
+                new Order(2, 2, 1, LocalDateTime.of(2024,5,2,9,2,0), null)))
+        .when(orderMapper).findAllOrders();
+        List<Order> actual = orderService.findAllOrders();
+        assertThat(actual).isEqualTo(List.of(
+                new Order(1, 1, 2, LocalDateTime.of(2024,5,2,9,0,0), LocalDateTime.of(2024,5,2,9,5,0)),
+                new Order(2, 2, 1, LocalDateTime.of(2024,5,2,9,2,0), null)));
+    }
+}


### PR DESCRIPTION
# 概要
現在実装しているREAD処理のServiceクラスに対する単体テストを実装した。
また、TimeStamp型への理解が難しく、Entityのフィールドの型をLocalDateTimeに変更するために、DBのカラムの型もDateTimeに変更した。
その他、メソッド名の変更も行なった。
# テスト内容
* データの全件取得(orderService,CarTypeService)
* 指定したIDデータの取得(CarTypeService)
* 指定したIDが存在しない場合例外がスローされること(CarTypeService)
# 動作確認
* OrderServiceTest  
<img width="400" alt="スクリーンショット 2024-05-22 14 19 09" src="https://github.com/pon02/Assignment-10/assets/140311845/25653698-a2c6-4fc7-8528-a7dcbc5bc2a8">

* CarTypeServiceTest  
<img width="400" alt="スクリーンショット 2024-05-22 14 18 19" src="https://github.com/pon02/Assignment-10/assets/140311845/af3c57ba-c430-4a41-a169-590561339ee9">

