### PR TITLE
READ処理に対する結合テストの実装

### DIFF
--- a/src/test/java/com/pon02/Assignment10/integrationtest/CarTypeIntegrationTest.java
+++ b/src/test/java/com/pon02/Assignment10/integrationtest/CarTypeIntegrationTest.java
@@ -1,0 +1,86 @@
+package com.pon02.Assignment10.integrationtest;
+
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.spring.api.DBRider;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.Customization;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.skyscreamer.jsonassert.comparator.CustomComparator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@DBRider
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class CarTypeIntegrationTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    @DataSet(value = "datasets/car_types/car_types.yml")
+    @Transactional
+    void 全てのカータイプが取得できること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/car-types"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        [
+                            {
+                                "id": 1,
+                                "carType": "セダン4人乗り",
+                                "capacity": 4
+                            },
+                            {
+                                "id": 2,
+                                "carType": "ハコバン7人乗り",
+                                "capacity": 7
+                            }
+                        ]
+                        """
+                ));
+    }
+
+    @Test
+    @DataSet(value = "datasets/car_types/car_types.yml")
+    @Transactional
+    void 指定したIDのカータイプが取得できること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/car-types/1"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        {
+                            "id": 1,
+                            "carType": "セダン4人乗り",
+                            "capacity": 4
+                        }
+                        """
+                ));
+    }
+
+    @Test
+    @DataSet(value = "datasets/car_types/car_types.yml")
+    @Transactional
+    void 存在しないIDのカータイプを取得しようとすると404エラーが返されること() throws Exception {
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/car-types/100"))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+        JSONAssert.assertEquals("""
+                {
+                    "timestamp": "2024-05-28T18:05:52.214069+09:00[Asia/Tokyo]",
+                    "path": "/car-types/100",
+                    "status": "404",
+                    "error": "Not Found"
+                }
+                """, response, new CustomComparator(JSONCompareMode.STRICT,
+                new Customization("timestamp", ((o1, o2) -> true))));
+    }
+}

--- a/src/test/java/com/pon02/Assignment10/integrationtest/CarTypeIntegrationTest.java
+++ b/src/test/java/com/pon02/Assignment10/integrationtest/CarTypeIntegrationTest.java
@@ -27,6 +27,8 @@ public class CarTypeIntegrationTest {
     @Autowired
     MockMvc mockMvc;
 
+
+    //GETメソッドでカータイプを全件取得しステータスコード200が返されること
     @Test
     @DataSet(value = "datasets/car_types/car_types.yml")
     @Transactional
@@ -50,6 +52,17 @@ public class CarTypeIntegrationTest {
                 ));
     }
 
+    //GETメソッドでカータイプが存在しない場合、空のリストを取得しステータスコード200が返されること
+    @Test
+    @DataSet(value = "datasets/car_types/car_type_empty.yml")
+    @Transactional
+    void カータイプが存在しない時に空のリストが返されること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/car-types"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("[]"));
+    }
+
+    //GETメソッドで指定したIDのカータイプを取得しステータスコード200が返されること
     @Test
     @DataSet(value = "datasets/car_types/car_types.yml")
     @Transactional
@@ -66,6 +79,7 @@ public class CarTypeIntegrationTest {
                 ));
     }
 
+    // GETメソッドで存在しないIDを指定した時に、例外がスローされステータスコード404とエラーメッセージが返されること
     @Test
     @DataSet(value = "datasets/car_types/car_types.yml")
     @Transactional

--- a/src/test/java/com/pon02/Assignment10/integrationtest/OrderIntegrationTest.java
+++ b/src/test/java/com/pon02/Assignment10/integrationtest/OrderIntegrationTest.java
@@ -21,6 +21,7 @@ public class OrderIntegrationTest {
     @Autowired
     MockMvc mockMvc;
 
+    //GETメソッドでオーダーを全件取得しステータスコード200が返されること
     @Test
     @DataSet(value = "datasets/orders/orders.yml")
     @Transactional
@@ -48,10 +49,11 @@ public class OrderIntegrationTest {
                 ));
     }
 
+    //GETメソッドでオーダーが存在しない場合、空のリストを取得しステータスコード200が返されること
     @Test
     @DataSet(value = "datasets/orders/order_empty.yml")
     @Transactional
-    void オーダーがない時に空のリストが返されること() throws Exception {
+    void オーダーが存在しない時に空のリストが返されること() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.get("/orders"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.content().json("[]"));

--- a/src/test/java/com/pon02/Assignment10/integrationtest/OrderIntegrationTest.java
+++ b/src/test/java/com/pon02/Assignment10/integrationtest/OrderIntegrationTest.java
@@ -1,0 +1,59 @@
+package com.pon02.Assignment10.integrationtest;
+
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.spring.api.DBRider;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@DBRider
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class OrderIntegrationTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    @DataSet(value = "datasets/orders/orders.yml")
+    @Transactional
+    void 全てのオーダーが取得できること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/orders"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        [
+                            {
+                                "id": 1,
+                                "carTypeId": 1,
+                                "orderStatusId": 2,
+                                "createdAt": "2024-05-02T09:00:00",
+                                "updatedAt": "2024-05-02T09:05:00"
+                            },
+                            {
+                                "id": 2,
+                                "carTypeId": 2,
+                                "orderStatusId": 1,
+                                "createdAt": "2024-05-02T09:02:00",
+                                "updatedAt": null
+                            }
+                        ]
+                        """
+                ));
+    }
+
+    @Test
+    @DataSet(value = "datasets/orders/order_empty.yml")
+    @Transactional
+    void オーダーがない時に空のリストが返されること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/orders"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("[]"));
+    }
+}


### PR DESCRIPTION
# 概要
現在実装しているREAD処理に対して結合テストを実装した。

# テスト内容
* データの全件取得(OrderIntegrationTest,CarTypeIntegrationTest)
* データがない場合空のリストが返されること(OrderIntegrationTest,CarTypeIntegrationTest)
* 指定したIDデータの取得(CarTypeIntegrationTest)
* 指定したIDが存在しない場合空で返されること(CarTypeIntegrationTest)

# 動作確認
* OrderIntegrationTest
<img width="400" alt="スクリーンショット 2024-05-28 19 52 27" src="https://github.com/pon02/Assignment-10/assets/140311845/dd513363-7b69-4d51-958c-cc11f449ecee">

* CarTypeIntegrationTest
<img width="400" alt="スクリーンショット 2024-05-28 19 53 51" src="https://github.com/pon02/Assignment-10/assets/140311845/c1dc1c3c-121f-4372-9d59-09407248cec2">


# 検討事項
SwaggerでAPI仕様書を作成していますが、結合テストを実装していると、不要なエラーレスポンスを記載しているように思えてきたので再度見直しをする予定です。
上記各パスのGETのレスポンスで400と404は不要と考えました。
自分で作成するアプリケーションにどのようなAPI仕様が必要もしくは不要なのかをまだ深く突き詰められていないと感じています。