### PR TITLE
PR#8にて修正箇所と関係なく自動テストが落ちたことへの検証

### DIFF
--- a/src/test/java/com/pon02/Assignment10/integrationtest/CarTypeIntegrationTest.java
+++ b/src/test/java/com/pon02/Assignment10/integrationtest/CarTypeIntegrationTest.java
@@ -130,7 +130,6 @@ public class CarTypeIntegrationTest {
     // POSTメソッドでリクエストのcarTypeNameが空文字や50文字を超える場合、または登録済みの車種名を入力された時に、
     // ステータスコード400とエラーメッセージが返されること
     @Transactional
-    @DataSet(cleanBefore = true, cleanAfter = true, value = "datasets/car_types/car_types.yml")
     @ParameterizedTest
     @MethodSource("provideStringsForValidation")
     void 新規登録時carTypeNameが不正な値の場合400エラーが返されること(String str,String expectedMessage) throws Exception {
@@ -161,7 +160,7 @@ public class CarTypeIntegrationTest {
         return Stream.of(
                 Arguments.of("", "必須項目です"),
                 Arguments.of("123456789012345678901234567890123456789012345678901", "50文字以内で入力してください"),
-                Arguments.of("セダン4人乗り", "この車種名はすでに登録されています")
+                Arguments.of("セダン4人", "この車種名はすでに登録されています")
         );
     }
 

--- a/src/test/java/com/pon02/Assignment10/integrationtest/CarTypeIntegrationTest.java
+++ b/src/test/java/com/pon02/Assignment10/integrationtest/CarTypeIntegrationTest.java
@@ -105,7 +105,7 @@ public class CarTypeIntegrationTest {
 
     // POSTメソッドで正しくリクエストした時に、カータイプが登録できステータスコード201とメッセージが返されること
     @Test
-    @DataSet(cleanBefore = true, cleanAfter = true, value = "datasets/car_types/car_types.yml")
+    @DataSet(value = "datasets/car_types/car_types.yml")
     @ExpectedDataSet(value = "datasets/car_types/insert_car_type.yml")
     @Transactional
     void カータイプが登録できること() throws Exception {

--- a/src/test/java/com/pon02/Assignment10/integrationtest/CarTypeIntegrationTest.java
+++ b/src/test/java/com/pon02/Assignment10/integrationtest/CarTypeIntegrationTest.java
@@ -131,6 +131,7 @@ public class CarTypeIntegrationTest {
     // ステータスコード400とエラーメッセージが返されること
     @ParameterizedTest
     @MethodSource("provideStringsForValidation")
+    @DataSet(value = "datasets/car_types/car_types.yml")
     @Transactional
     void 新規登録時carTypeNameが不正な値の場合400エラーが返されること(String str,String expectedMessage) throws Exception {
         String response = mockMvc.perform(MockMvcRequestBuilders.post("/car-types")

--- a/src/test/java/com/pon02/Assignment10/integrationtest/CarTypeIntegrationTest.java
+++ b/src/test/java/com/pon02/Assignment10/integrationtest/CarTypeIntegrationTest.java
@@ -44,12 +44,12 @@ public class CarTypeIntegrationTest {
                         [
                             {
                                 "id": 1,
-                                "carTypeName": "セダン4人乗り",
+                                "carTypeName": "セダン4人",
                                 "capacity": 4
                             },
                             {
                                 "id": 2,
-                                "carTypeName": "ハコバン7人乗り",
+                                "carTypeName": "ハコバン7人",
                                 "capacity": 7
                             }
                         ]
@@ -77,7 +77,7 @@ public class CarTypeIntegrationTest {
                 .andExpect(MockMvcResultMatchers.content().json("""
                         {
                             "id": 1,
-                            "carTypeName": "セダン4人乗り",
+                            "carTypeName": "セダン4人",
                             "capacity": 4
                         }
                         """
@@ -113,7 +113,7 @@ public class CarTypeIntegrationTest {
                         .contentType("application/json")
                         .content("""
                                 {
-                                    "carTypeName": "ハイエース9人乗り",
+                                    "carTypeName": "ハイエース9人",
                                     "capacity": 9
                                 }
                                 """))
@@ -129,9 +129,9 @@ public class CarTypeIntegrationTest {
 
     // POSTメソッドでリクエストのcarTypeNameが空文字や50文字を超える場合、または登録済みの車種名を入力された時に、
     // ステータスコード400とエラーメッセージが返されること
-    @Transactional
     @ParameterizedTest
     @MethodSource("provideStringsForValidation")
+    @Transactional
     void 新規登録時carTypeNameが不正な値の場合400エラーが返されること(String str,String expectedMessage) throws Exception {
         String response = mockMvc.perform(MockMvcRequestBuilders.post("/car-types")
                         .contentType("application/json")
@@ -173,7 +173,7 @@ public class CarTypeIntegrationTest {
                         .contentType("application/json")
                         .content("""
                                 {
-                                    "carTypeName": "ハイエース9人乗り",
+                                    "carTypeName": "ハイエース9人",
                                     "capacity": null
                                 }
                                 """))

--- a/src/test/java/com/pon02/Assignment10/mapper/CarTypeMapperTest.java
+++ b/src/test/java/com/pon02/Assignment10/mapper/CarTypeMapperTest.java
@@ -30,8 +30,8 @@ class CarTypeMapperTest {
         assertThat(carTypes)
                 .hasSize(2)
                 .contains(
-                        new CarType(1, "セダン4人乗り",4),
-                        new CarType(2, "ハコバン7人乗り",7)
+                        new CarType(1, "セダン4人",4),
+                        new CarType(2, "ハコバン7人",7)
                 );
     }
 
@@ -47,7 +47,7 @@ class CarTypeMapperTest {
     @Transactional
     void カータイプIDでカータイプが取得できること() {
         Optional<CarType> carType = carTypeMapper.findCarTypeById(1);
-        assertThat(carType).contains(new CarType(1, "セダン4人乗り",4));
+        assertThat(carType).contains(new CarType(1, "セダン4人",4));
     }
 
     @Test
@@ -62,7 +62,7 @@ class CarTypeMapperTest {
     @DataSet(cleanBefore = true)
     @Transactional
     void カータイプが追加されること() {
-        CarType carType = new CarType("セダン4人乗", 4);
+        CarType carType = new CarType("セダン4人", 4);
         carTypeMapper.insertCarType(carType);
         List<CarType> carTypes = carTypeMapper.findAllCarTypes();
         assertThat(carTypes)

--- a/src/test/resources/datasets/car_types/car_types.yml
+++ b/src/test/resources/datasets/car_types/car_types.yml
@@ -1,7 +1,7 @@
 car_types:
   - id: 1
-    car_type: セダン4人乗り
+    car_type: セダン4人
     capacity: 4
   - id: 2
-    car_type: ハコバン7人乗り
+    car_type: ハコバン7人
     capacity: 7

--- a/src/test/resources/datasets/car_types/insert_car_type.yml
+++ b/src/test/resources/datasets/car_types/insert_car_type.yml
@@ -1,7 +1,7 @@
 car_types:
-  - car_type: セダン4人乗り
+  - car_type: セダン4人
     capacity: 4
-  - car_type: ハコバン7人乗り
+  - car_type: ハコバン7人
     capacity: 7
-  - car_type: ハイエース9人乗り
+  - car_type: ハイエース9人
     capacity: 9


### PR DESCRIPTION
# 概要
PR#8にてテスト名が冗長なものだったのを短く修正した際、PR作成時に通っていた自動テストが落ちた。
297be10b93f451b299c96c534447771f4e8d57c6  
修正箇所の影響と考えにくかったため、原因を探った。
# 調査手順
* 自動テストのエラー箇所
<img width="400" alt="スクリーンショット 2024-08-02 17 19 24" src="https://github.com/user-attachments/assets/d04dee16-f555-448c-9c7b-71f9db19c8b4">

Nameの重複でバリデーションが効くはずが登録できてしまっていた。
→データベースの構築がうまくいっていない？

* workflowのrun_test.ymlの不備を疑いコードの再確認　→問題なし

* ローカル環境でもいつの間にかデータベース内のcar-typesテーブルが空になっていることに気づき、volumeとimageを一度削除して再度Dockerを立ち上げるとcar-typesテーブルが正しく存在。    

* Dockerでのデータベース構築に何かエラーが発生しているのではと思い、ログやvolumeの設定を確認　→問題なし

* 該当のテストコードの@Transactionalの境界を確認　→問題なし

* ローカル環境では該当のテスト単体で実行すると成功するが、CarTypeIntegrationTestクラスを全て実行するとテストが該当箇所で落ちることを確認
→　一つ前のテストで使用していたclean before,clean afterの使用法を再確認、データベースに直接影響してデータを消していると気づき削除したところ、クラスごとのテストも通るようになった。

# 結論
clean before,clean afterの使用方法を「元々のDBデータを@DataSet前にテストに影響させなくするもの」と解釈していたが、「今あるデータベースの中身を消す」という直接的な働きに気づいておらず、これによりデータベース内のcar_typesテーブルを削除していた。  
他のクラス内のテストには@DataSet(value=~ ) を付与していたが、エラーが出た該当のテストのみ付与しておらずエラーに繋がったものと思われる。
datasetsを利用して仮想データでテストを行う際は@DataSet(value=~ ) のみで問題ないと気づき、clean before,clean afterを削除してpushしたところ自動テストが通った。

# 懸念点
逆にPR作成時に自動テストが通ったことがおかしいことになりますが、PR作成時commitを修正したくforce pushをしていたりしたので、バグが起こっていたと考えることはできますでしょうか。
もしくはrun_test.ymlにおいてデータベース構築に不安定な要素があるのでは、とも思って現在調べているのですが、workflowの記述についてまだまだ理解が足りておらずその結論には至れていません。